### PR TITLE
chore: Bump up hedgedoc to 1.10.5

### DIFF
--- a/notes.Dockerfile
+++ b/notes.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/hedgedoc/hedgedoc:1.10.3
+FROM quay.io/hedgedoc/hedgedoc:1.10.5
 
 ARG UID=10000
 COPY --chown=$UID /s3-upload.js /hedgedoc/lib/web/imageRouter/s3.js

--- a/private.Dockerfile
+++ b/private.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/hedgedoc/hedgedoc:1.10.3
+FROM quay.io/hedgedoc/hedgedoc:1.10.5
 
 ARG UID=10000
 COPY --chown=$UID /oauth-index.js /hedgedoc/lib/web/auth/oauth2/index.js


### PR DESCRIPTION
Hedgedoc 1.10.4 includes security fixes[^1].

We might want to look at using `CMD_ENABLE_UPLOADS` but there's an already issue with image uploads[^2].
>Add enableUploads (CMD_ENABLE_UPLOADS) config option to restrict uploads to registered users, all users or none to completely disable uploads.

[^1]: https://github.com/hedgedoc/hedgedoc/releases/tag/1.10.4
[^2]: https://github.com/ietf-tools/hedgedoc/issues/8