### PR TITLE
chore: Bump up hedgedoc to 1.10.7

### DIFF
--- a/notes.Dockerfile
+++ b/notes.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/hedgedoc/hedgedoc:1.10.6
+FROM quay.io/hedgedoc/hedgedoc:1.10.7
 
 ARG UID=10000
 COPY --chown=$UID /s3-upload.js /hedgedoc/lib/web/imageRouter/s3.js

--- a/private.Dockerfile
+++ b/private.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/hedgedoc/hedgedoc:1.10.6
+FROM quay.io/hedgedoc/hedgedoc:1.10.7
 
 ARG UID=10000
 COPY --chown=$UID /oauth-index.js /hedgedoc/lib/web/auth/oauth2/index.js


### PR DESCRIPTION
Release notes: https://github.com/hedgedoc/hedgedoc/releases/tag/1.10.7