### PR TITLE
feat: Add managed domains to external allow links

### DIFF
--- a/notes.Dockerfile
+++ b/notes.Dockerfile
@@ -23,3 +23,4 @@ ENV CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR=name
 ENV CMD_PROTOCOL_USESSL=true
 ENV CMD_URL_ADDPORT=false
 ENV CMD_RATE_LIMIT_USING_CLOUDFLARE=true
+ENV CMD_EXTERNAL_LINK_WHITELIST="ietf.org, *.ietf.org, iab.org, *.iab.org, irtf.org, *.irtf.org, rfc-editor.org, *.rfc-editor.org"

--- a/private.Dockerfile
+++ b/private.Dockerfile
@@ -18,3 +18,4 @@ ENV CMD_OAUTH2_USER_PROFILE_URL=https://auth.ietf.org/api/openid/userinfo
 ENV CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR=name
 ENV CMD_OAUTH2_ROLES_CLAIM=roles
 ENV CMD_RATE_LIMIT_USING_CLOUDFLARE=true
+ENV CMD_EXTERNAL_LINK_WHITELIST="ietf.org, *.ietf.org, iab.org, *.iab.org, irtf.org, *.irtf.org, rfc-editor.org, *.rfc-editor.org"


### PR DESCRIPTION
Fixes #12 

Requires [HedgeDoc 1.11.1](https://github.com/hedgedoc/hedgedoc/releases/tag/1.11.1).
Configuration docs: https://docs.hedgedoc.org/configuration/#hedgedoc-basics